### PR TITLE
Albedo CLI - Remove logic to "automagically" set plot labels.

### DIFF
--- a/.github/workflows/pytest_flake8.yml
+++ b/.github/workflows/pytest_flake8.yml
@@ -16,19 +16,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
-      with:
-        activate-environment: spectro-dp
-        environment-file: environment.yml
-        auto-activate-base: false
-    - name: Install development dependencies
-      run: |
-        conda env update --file environment_dev.yml
-    - name: Install package
-      run: |
-        pip install -e .
-    - name: Test with pytest
-      run: |
-        pytest tests/
-    - name: Lint with flake8
-      run: |
-        flake8 . --count --show-source --statistics
+        with:
+          activate-environment: spectro-dp
+          environment-file: environment.yml
+          auto-activate-base: false
+      - name: Install development dependencies
+        run: |
+          conda env update --file environment_dev.yml
+      - name: Install package
+        run: |
+          pip install -e .
+      - name: Test with pytest
+        run: |
+          pytest tests/
+      - name: Lint with flake8
+        run: |
+          flake8 . --count --show-source --statistics

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python<3.10
-  - numpy<1.22
+  - python
+  - numpy
   - matplotlib<3.5
   - click<8.1

--- a/src/spectro_dp/asd/albedo.py
+++ b/src/spectro_dp/asd/albedo.py
@@ -64,7 +64,8 @@ def cli(
 ):
     try:
         composite = MeasurementComposite(
-            input_dir, file_prefix, down_index, up_index,
+            input_dir, file_prefix,
+            set_1_index=down_index, set_2_index=up_index,
             set_1_count=down_count, set_2_count=up_count,
             debug=debug
         )
@@ -72,12 +73,8 @@ def cli(
 
         print(f"Results saved to:\n  {composite.save(output_file_suffix)}")
 
-        if composite.set_2.mean() < composite.set_1.mean():
-            set_1_label = 'Incoming'
-            set_2_label = 'Outgoing'
-        else:
-            set_1_label = 'Outgoing'
-            set_2_label = 'Incoming'
+        set_1_label = 'Down Measurements'
+        set_2_label = 'Up Measurements'
 
         if not skip_plot:
             Plotter.show_composite(

--- a/tests/asd/test_measurement_file.py
+++ b/tests/asd/test_measurement_file.py
@@ -51,7 +51,7 @@ class TestMeasurement(object):
         assert subject.data.size == MeasurementFile.BAND_COUNT
 
     def test_header_return_type(self, subject):
-        assert type(subject.header) == str
+        assert isinstance(subject.header, str)
 
     def test_header(self, subject):
         assert subject.header == 'ASDAtwater test'


### PR DESCRIPTION
Hard-code the labels matching the input args to easier identify potential mix-and-match of input files.